### PR TITLE
feat: add DockClicker event filter

### DIFF
--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -83,6 +83,8 @@ DOS_API void DOS_CALL dos_qguiapplication_delete(void);
 
 DOS_API void dos_qapplication_clipboard_setText(const char* text);
 
+DOS_API void dos_qapplication_installEventFilter(DosQQmlApplicationEngine *vptr);
+
 /// @}
 
 /// \defgroup QApplication QApplication


### PR DESCRIPTION
Add an event filter to `qApp` that can detect a dock icon click (in macos) when the main window is hidden or closed.