### PR TITLE
fix(@desktop/general): right click the icon on the dock and press quit doesn't quit the app (macos)

### DIFF
--- a/lib/include/DOtherSide/DOtherSideStatusWindow.h
+++ b/lib/include/DOtherSide/DOtherSideStatusWindow.h
@@ -25,6 +25,9 @@ public:
         }
     }
 
+protected:
+    bool event(QEvent *e) override;
+
 signals:
     void isFullScreenChanged();
 

--- a/lib/src/DOtherSideStatusWindow.cpp
+++ b/lib/src/DOtherSideStatusWindow.cpp
@@ -1,5 +1,7 @@
 #include "DOtherSide/DOtherSideStatusWindow.h"
 
+#include <QApplication>
+
 StatusWindow::StatusWindow(QWindow *parent)
 : QQuickWindow(parent),
   m_isFullScreen(false)
@@ -31,4 +33,16 @@ void StatusWindow::toggleFullScreen()
 bool StatusWindow::isFullScreen() const
 {
 	return m_isFullScreen;
+}
+
+bool StatusWindow::event(QEvent* event)
+{
+    if (event->type() == QEvent::Close)
+    {
+        event->ignore();
+        qApp->quit();
+        return true;
+    }
+
+    return QQuickWindow::event(event);
 }


### PR DESCRIPTION
This issue is reproducible on the app only if you're not logged in yet.
The issue is fixed by custom handling QEvent::Close.

Fixes: #3112