### PR TITLE
fix(@desktop/general): clicking push notification does expand the app but does not open correct channel/chat

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,45 +6,14 @@ include(GNUInstallDirs)
 macro(add_target name type)
     find_package(Qt5 COMPONENTS Core Qml Gui Quick QuickControls2 Widgets Network REQUIRED)
 
-    add_library(${name} ${type}
-        include/DOtherSide/DOtherSideTypes.h
-        include/DOtherSide/DOtherSideTypesCpp.h
-        include/DOtherSide/DOtherSide.h
-        include/DOtherSide/DosQDeclarative.h
-        include/DOtherSide/DosQObjectWrapper.h
-        include/DOtherSide/DosQAbstractItemModelWrapper.h
-        include/DOtherSide/DosQObject.h
-        include/DOtherSide/DosQObjectImpl.h
-        include/DOtherSide/DosIQObjectImpl.h
-        include/DOtherSide/DosQMetaObject.h
-        include/DOtherSide/DosIQAbstractItemModelImpl.h
-        include/DOtherSide/DosQAbstractItemModel.h
-        include/DOtherSide/Utils.h
-        include/DOtherSide/StatusEvents/StatusDockShowAppEvent.h
-        include/DOtherSide/StatusEvents/StatusOSThemeEvent.h
-        include/DOtherSide/DOtherSideStatusWindow.h
-        include/DOtherSide/DOtherSideSingleInstance.h
-        include/DOtherSide/DOtherSideStatusSyntaxHighlighter.h
-        src/DOtherSide.cpp
-        src/DosQMetaObject.cpp
-        src/DosQDeclarative.cpp
-        src/DosQObject.cpp
-        src/DOtherSideTypesCpp.cpp
-        src/DosQObjectImpl.cpp
-        src/DosQAbstractItemModel.cpp
-        src/DosQQuickImageProvider.cpp
-        src/StatusEvents/StatusDockShowAppEvent.cpp
-        src/StatusEvents/StatusOSThemeEvent.cpp
-        src/DOtherSideStatusWindow.cpp
-        src/DOtherSideSingleInstance.cpp
-        src/DOtherSideStatusSyntaxHighlighter.cpp
-    )
-
-    if (APPLE)
-        target_sources(${name} PUBLIC src/DOtherSideStatusWindow_osx.mm)
+    file(GLOB_RECURSE HEADERS include/DOtherSide/*.h)
+    if(APPLE)
+        file(GLOB_RECURSE SOURCES src/*.cpp src/*.mm)
     else()
-        target_sources(${name} PUBLIC ${CMAKE_SOURCE_DIR}/lib/src/DOtherSideStatusWindow_other.cpp)
+        file(GLOB_RECURSE SOURCES src/*.cpp)
     endif()
+
+    add_library(${name} ${type} ${SOURCES} ${HEADERS})
 
     if (WIN32)
         target_compile_definitions(${name} PRIVATE -DWIN32)

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -1002,6 +1002,12 @@ DOS_API DosStatusEventObject* dos_statusevent_create_showAppEvent(DosQQmlApplica
 DOS_API DosStatusEventObject* dos_statusevent_create_osThemeEvent(DosQQmlApplicationEngine* vptr);
 DOS_API void dos_statusevent_delete(DosStatusEventObject* vptr);
 
+/// Status notification object
+DOS_API DosStatusOSNotificationObject* dos_statusosnotification_create();
+DOS_API void dos_statusosnotification_show_notification(DosStatusOSNotificationObject* vptr, 
+    const char* title, const char* message, const char* identifier);
+DOS_API void dos_statusosnotification_delete(DosStatusOSNotificationObject* vptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/include/DOtherSide/DOtherSideTypes.h
+++ b/lib/include/DOtherSide/DOtherSideTypes.h
@@ -101,6 +101,9 @@ typedef void DosSingleInstance;
 /// A pointer to a status event object which is actualy a QObject
 typedef void DosStatusEventObject;
 
+/// A pointer to a status os notification object which is actualy a QObject
+typedef DosQObject DosStatusOSNotificationObject;
+
 /// A pixmap callback to be supplied to an image provider
 /// \param id Image source id
 /// \param width pointer to the width of the image

--- a/lib/include/DOtherSide/StatusNotification/StatusOSNotification.h
+++ b/lib/include/DOtherSide/StatusNotification/StatusOSNotification.h
@@ -5,7 +5,7 @@
 #include <QHash>
 
 #ifdef Q_OS_WIN
-
+#include "windows.h"
 #elif defined Q_OS_MACOS
 class NotificationHelper;
 #endif
@@ -25,6 +25,15 @@ signals:
     void notificationClicked(QString identifier);
 
 #ifdef Q_OS_WIN
+public:
+    QHash<uint, QString> m_identifiers;
+
+private:
+    bool initNotificationWin();
+    void stringToLimitedWCharArray(QString in, wchar_t* target, int maxLength);
+
+private:
+    HWND m_hwnd;
 
 #elif defined Q_OS_MACOS
 private:

--- a/lib/include/DOtherSide/StatusNotification/StatusOSNotification.h
+++ b/lib/include/DOtherSide/StatusNotification/StatusOSNotification.h
@@ -1,0 +1,39 @@
+#ifndef STATUS_OS_NOTIFICATION_H
+#define STATUS_OS_NOTIFICATION_H
+
+#include <QObject>
+#include <QHash>
+
+#ifdef Q_OS_WIN
+
+#elif defined Q_OS_MACOS
+class NotificationHelper;
+#endif
+
+class StatusOSNotification : public QObject
+{
+    Q_OBJECT
+
+public:
+    StatusOSNotification(QObject *parent = nullptr);
+    ~StatusOSNotification();
+
+    void showNotification(const QString& title, const QString& message, 
+    const QString& identifier);
+
+signals:
+    void notificationClicked(QString identifier);
+
+#ifdef Q_OS_WIN
+
+#elif defined Q_OS_MACOS
+private:
+    void initNotificationMacOs();
+    void showNotificationMacOs(QString title, QString message, QString identifier);
+
+private:
+    NotificationHelper *m_notificationHelper;
+#endif
+};
+
+#endif

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -63,6 +63,7 @@
 
 #include "DOtherSide/StatusEvents/StatusDockShowAppEvent.h"
 #include "DOtherSide/StatusEvents/StatusOSThemeEvent.h"
+#include "DOtherSide/StatusNotification/StatusOSNotification.h"
 
 namespace {
 
@@ -135,7 +136,7 @@ void dos_qapplication_initialize_opengl()
 void dos_qguiapplication_create()
 {
     static int argc = 1;
-    static char *argv[] = {"Status"};
+    static char *argv[] = {(char*)"Status"};
 
     register_meta_types();
 
@@ -201,7 +202,7 @@ void dos_qguiapplication_installEventFilter(::DosStatusEventObject* vptr)
 void dos_qapplication_create()
 {
     static int argc = 1;
-    static char *argv[] = {"Status"};
+    static char *argv[] = {(char*)"Status"};
 
     register_meta_types();
 
@@ -1360,4 +1361,24 @@ void dos_statusevent_delete(DosStatusEventObject* vptr)
 {
     auto qobject = static_cast<QObject*>(vptr);
     qobject->deleteLater();
+}
+
+::DosStatusOSNotificationObject* dos_statusosnotification_create()
+{
+    return new StatusOSNotification();
+}
+
+void dos_statusosnotification_show_notification(DosStatusOSNotificationObject* vptr, 
+    const char* title, const char* message, const char* identifier)
+{
+    auto notificationObj = static_cast<StatusOSNotification*>(vptr);
+    if(notificationObj)
+        notificationObj->showNotification(title, message, identifier);
+}
+
+void dos_statusosnotification_delete(DosStatusOSNotificationObject* vptr)
+{
+    auto qobject = static_cast<QObject*>(vptr);
+    if(qobject)
+        qobject->deleteLater();
 }

--- a/lib/src/StatusNotification/StatusOSNotification.cpp
+++ b/lib/src/StatusNotification/StatusOSNotification.cpp
@@ -1,10 +1,23 @@
 #include "DOtherSide/StatusNotification/StatusOSNotification.h"
 
+#ifdef Q_OS_WIN
+#include <shellapi.h>
+#include <stdlib.h>
+#include <string.h>
+#include <winuser.h>
+#include <comdef.h>
+
+static const UINT NOTIFYICONID = 0;
+
+static std::pair<HWND, StatusOSNotification *> HWND_INSTANCE_PAIR;
+#endif
+
 StatusOSNotification::StatusOSNotification(QObject *parent)
     : QObject(parent)
 {
 #ifdef Q_OS_WIN
-
+    m_hwnd = nullptr;
+    initNotificationWin();
 #elif defined Q_OS_MACOS
     m_notificationHelper = nullptr;
     initNotificationMacOs();
@@ -21,10 +34,123 @@ StatusOSNotification::~StatusOSNotification()
 #endif
 }
 
+#ifdef Q_OS_WIN
+LRESULT CALLBACK StatusWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    const int msgInfo = LOWORD(lParam);
+
+    if (hwnd == HWND_INSTANCE_PAIR.first 
+        && HWND_INSTANCE_PAIR.second 
+        && HWND_INSTANCE_PAIR.second->m_identifiers.contains(uMsg) 
+        && msgInfo == NIN_BALLOONUSERCLICK)
+    {
+        HWND_INSTANCE_PAIR.second->notificationClicked(
+            HWND_INSTANCE_PAIR.second->m_identifiers[uMsg]);
+        return 0;
+    }
+
+    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+}
+
+void StatusOSNotification::stringToLimitedWCharArray(QString in, wchar_t* target, 
+    int maxLength)
+{
+    const int length = qMin(maxLength - 1, in.size());
+    if (length < in.size())
+        in.truncate(length);
+    in.toWCharArray(target);
+    target[length] = wchar_t(0);
+}
+
+bool StatusOSNotification::initNotificationWin()
+{
+    // m_hwnd should be init only once, but that would be a case if we create system 
+    // tray window from here. But since we already have system tray added in the
+    // app we're just refering to that already added window and listen for events
+    // on it. HWND of that window may be changed during the runtime and we don't
+    // have an option to be notified about that, that's why we're searching for 
+    // appropriate HWND each time we need it, and that's why the following two
+    // lines are commented out.
+    //
+    // if (m_hwnd)
+    //     return true;
+
+    const QString cName = "QTrayIconMessageWindowClass";
+    LPCSTR className = cName.toStdString().c_str();
+    const QString wName = "QTrayIconMessageWindow";
+    LPCSTR windowName = wName.toStdString().c_str();
+
+    const auto appInstance = static_cast<HINSTANCE>(GetModuleHandle(nullptr));
+
+    WNDCLASSEX wc;
+    wc.cbSize = sizeof(WNDCLASSEX);
+    wc.style = CS_HREDRAW | CS_VREDRAW;
+    wc.lpfnWndProc = StatusWndProc;
+    wc.cbClsExtra = 0;
+    wc.cbWndExtra = 0;
+    wc.hInstance = appInstance;
+    wc.hCursor = nullptr;
+    wc.hbrBackground = (HBRUSH)(COLOR_WINDOW);
+    wc.hIcon = nullptr;
+    wc.hIconSm = nullptr;
+    wc.lpszMenuName = nullptr;
+    wc.lpszClassName = className;
+
+    ATOM atom = RegisterClassEx(&wc);
+    if (!atom)
+        printf("StatusOsNotification registering window class failed.\n");
+
+    m_hwnd = FindWindowExA(0, 0, className, windowName);
+    if(m_hwnd)
+    {
+        HWND_INSTANCE_PAIR = std::make_pair(m_hwnd, this);
+        return true;
+    }
+
+    return false;
+}
+#endif
+
 void StatusOSNotification::showNotification(const QString& title, 
     const QString& message, const QString& identifier)
 {
 #ifdef Q_OS_WIN
+    if (!initNotificationWin())
+    {
+        return;
+    }
+
+    NOTIFYICONDATA tnd;
+    memset(&tnd, 0, sizeof(NOTIFYICONDATA));
+    tnd.cbSize = sizeof(NOTIFYICONDATA);
+    tnd.uVersion = NOTIFYICON_VERSION_4;
+
+    QString t = title;
+    wchar_t wcTitle[64];    
+    stringToLimitedWCharArray(t, wcTitle, 64);
+    _bstr_t bT(wcTitle);
+    const char* cTitle = bT;
+
+    QString m = message;
+    wchar_t wcMessage[256];
+    stringToLimitedWCharArray(m, wcMessage, 256);
+    _bstr_t bM(wcMessage);
+    const char* cMessage = bM;
+
+    strncpy_s(tnd.szInfoTitle, sizeof(tnd.szInfoTitle), cTitle, strlen(cTitle));
+    strncpy_s(tnd.szInfo, sizeof(tnd.szInfo), cMessage, strlen(cMessage));
+
+    tnd.uID = NOTIFYICONID;
+    tnd.hWnd = m_hwnd;
+    tnd.dwInfoFlags = NIIF_INFO;
+    tnd.uTimeout = UINT(10000);
+    tnd.uFlags = NIF_MESSAGE | NIF_INFO | NIF_SHOWTIP;
+
+    uint id = WM_APP + 2 + m_identifiers.size();
+    m_identifiers.insert(id, identifier);
+    tnd.uCallbackMessage = id;
+
+    Shell_NotifyIcon(NIM_MODIFY, &tnd);
 
 #elif defined Q_OS_MACOS
     showNotificationMacOs(title, message, identifier);

--- a/lib/src/StatusNotification/StatusOSNotification.cpp
+++ b/lib/src/StatusNotification/StatusOSNotification.cpp
@@ -1,0 +1,32 @@
+#include "DOtherSide/StatusNotification/StatusOSNotification.h"
+
+StatusOSNotification::StatusOSNotification(QObject *parent)
+    : QObject(parent)
+{
+#ifdef Q_OS_WIN
+
+#elif defined Q_OS_MACOS
+    m_notificationHelper = nullptr;
+    initNotificationMacOs();
+#endif
+}
+
+StatusOSNotification::~StatusOSNotification()
+{
+#ifdef Q_OS_MACOS
+    if(m_notificationHelper)
+    {
+        delete m_notificationHelper;
+    }
+#endif
+}
+
+void StatusOSNotification::showNotification(const QString& title, 
+    const QString& message, const QString& identifier)
+{
+#ifdef Q_OS_WIN
+
+#elif defined Q_OS_MACOS
+    showNotificationMacOs(title, message, identifier);
+#endif
+}

--- a/lib/src/StatusNotification/StatusOSNotification.mm
+++ b/lib/src/StatusNotification/StatusOSNotification.mm
@@ -1,0 +1,78 @@
+#include "DOtherSide/StatusNotification/StatusOSNotification.h"
+
+#ifdef Q_OS_MACOS
+
+#import <AppKit/AppKit.h>
+
+@interface NotificationDelegate : NSObject <NSUserNotificationCenterDelegate>
+- (instancetype)initStatusOSNotification:(StatusOSNotification*) instance;
+@end
+
+class NotificationHelper
+{
+public:
+    NotificationHelper(StatusOSNotification* instance) {
+        delegate = [[NotificationDelegate alloc] initStatusOSNotification:instance];
+        NSUserNotificationCenter.defaultUserNotificationCenter.delegate = delegate;
+    }
+
+    ~NotificationHelper() {
+        NSUserNotificationCenter *center = NSUserNotificationCenter.defaultUserNotificationCenter;
+        if (center.delegate == delegate)
+            center.delegate = nil;
+        [delegate release];
+    }
+
+    NotificationDelegate* delegate;
+};
+
+void StatusOSNotification::initNotificationMacOs()
+{
+    if (!m_notificationHelper)
+    {
+        m_notificationHelper = new NotificationHelper(this);
+    }
+}
+
+void StatusOSNotification::showNotificationMacOs(QString title, QString message, 
+    QString identifier)
+{
+    if (!m_notificationHelper)
+        return;
+
+    NSUserNotification* notification = [[NSUserNotification alloc] init];
+    notification.title = title.toNSString();
+    notification.informativeText = message.toNSString();
+    notification.soundName = NSUserNotificationDefaultSoundName;
+    notification.hasActionButton = false;
+    notification.identifier = identifier.toNSString();
+    
+    NSUserNotificationCenter* center = NSUserNotificationCenter.defaultUserNotificationCenter;
+    center.delegate = m_notificationHelper->delegate;
+    [center deliverNotification:notification];
+    [notification release];
+}
+
+@implementation NotificationDelegate {
+    StatusOSNotification* instance;
+}
+
+- (instancetype)initStatusOSNotification:(StatusOSNotification*)ins
+{
+    self = [super init];
+    if (self) {
+        instance = ins;
+    }
+    return self;
+}
+
+- (void) userNotificationCenter:(NSUserNotificationCenter*)center didActivateNotification:(NSUserNotification*)notification 
+{
+    const char* identifier = [notification.identifier UTF8String];
+    [center removeDeliveredNotification:notification];
+    
+    instance->notificationClicked(identifier);
+}
+@end
+
+#endif


### PR DESCRIPTION
Adding notifications for MacOS and Windows in an OS native way applied. For Windows we're referring to an already added HWND which is created adding the app to a system tray.