### PR TITLE
Fix/SystemTrayIcon

### DIFF
--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -126,8 +126,8 @@ char *dos_qcoreapplication_application_dir_path()
 
 void dos_qapplication_enable_hdpi(const char *uiScaleFilePath)
 {
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 
     QFile scaleFile(QString::fromUtf8(uiScaleFilePath));
     if (scaleFile.open(QIODevice::ReadOnly)) {
@@ -138,7 +138,7 @@ void dos_qapplication_enable_hdpi(const char *uiScaleFilePath)
 
 void dos_qapplication_initialize_opengl()
 {
-    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+    QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 }
 
 void dos_qguiapplication_create()

--- a/lib/src/DOtherSideStatusSyntaxHighlighter.cpp
+++ b/lib/src/DOtherSideStatusSyntaxHighlighter.cpp
@@ -21,8 +21,7 @@ StatusSyntaxHighlighter::StatusSyntaxHighlighter(QTextDocument *parent)
 //ITALIC
 
 //CODE
-    singlelineCodeBlockFormat.setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-    singlelineCodeBlockFormat.setFontPointSize(15);
+    singlelineCodeBlockFormat.setFontFamily("Roboto Mono");
     rule.pattern = QRegularExpression(QStringLiteral("\\`(.*?)\\`"));
     rule.format = singlelineCodeBlockFormat;
     highlightingRules.append(rule);
@@ -36,8 +35,7 @@ StatusSyntaxHighlighter::StatusSyntaxHighlighter(QTextDocument *parent)
 //STRIKETHROUGH
 
 //CODE BLOCK
-    multiLineCodeBlockFormat.setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-    multiLineCodeBlockFormat.setFontPointSize(15);
+    multiLineCodeBlockFormat.setFontFamily("Roboto Mono");
     rule.pattern = QRegularExpression(QStringLiteral("\\`\\`\\`(.*?)\\`\\`\\`"));
     rule.format = multiLineCodeBlockFormat;
     highlightingRules.append(rule);


### PR DESCRIPTION
QML SystemTrayIcon is very sensitive to when QCoreApplication is used instead of QGuiApplication. It just stops working. Hence we need to be very careful when dealing with QCoreApplication vs QGuiApplication vs QApplication.