### PR TITLE
QGuiApplication to not mess with QCoreApplication and QApplication

### DIFF
--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -44,25 +44,21 @@ extern "C"
 {
 #endif
 
-/// \defgroup QGuiApplication QGuiApplication
-/// \brief Functions related to the QGuiApplication class
-/// @{
-
 /// \brief Return the QCore::applicationDirPath
 /// \return The QCore::applicationDirPath as a UTF-8 string
 /// \note The returned string should be deleted by the calling code by using
 /// the dos_chararray_delete() function
-DOS_API char *DOS_CALL dos_qcoreapplication_application_dir_path(void);
+DOS_API char *DOS_CALL dos_qguiapplication_application_dir_path(void);
 
 /// \brief Force the event loop to spin and process the given events
-DOS_API void DOS_CALL dos_qcoreapplication_process_events(DosQEventLoopProcessEventFlag flags = DosQEventLoopProcessEventFlag::DosQEventLoopProcessEventFlagProcessAllEvents);
+DOS_API void DOS_CALL dos_qguiapplication_process_events(DosQEventLoopProcessEventFlag flags = DosQEventLoopProcessEventFlag::DosQEventLoopProcessEventFlagProcessAllEvents);
 
 /// \brief Force the event loop to spin and process the given events until no more available or timed out
-DOS_API void DOS_CALL dos_qcoreapplication_process_events_timed(DosQEventLoopProcessEventFlag flags, int ms);
+DOS_API void DOS_CALL dos_qguiapplication_process_events_timed(DosQEventLoopProcessEventFlag flags, int ms);
 
-DOS_API void DOS_CALL dos_qapplication_enable_hdpi(const char *uiScaleFilePath);
+DOS_API void DOS_CALL dos_qguiapplication_enable_hdpi(const char *uiScaleFilePath);
 
-DOS_API void DOS_CALL dos_qapplication_initialize_opengl(void);
+DOS_API void DOS_CALL dos_qguiapplication_initialize_opengl(void);
 
 /// \brief Create a QGuiApplication
 /// \note The created QGuiApplication should be freed by calling dos_qguiapplication_delete()
@@ -84,27 +80,17 @@ DOS_API void DOS_CALL dos_qguiapplication_icon(const char *filename);
 
 DOS_API void dos_qguiapplication_installEventFilter(DosEvent *vptr);
 
-DOS_API void dos_qapplication_clipboard_setText(const char* text);
+DOS_API void dos_qguiapplication_clipboard_setText(const char* text);
 
-DOS_API void dos_qapplication_installEventFilter(DosEvent *vptr);
+DOS_API void dos_qguiapplication_installEventFilter(DosStatusEventObject *vptr);
 
-DOS_API void dos_qapplication_clipboard_setImage(const char *text);
+DOS_API void dos_qguiapplication_clipboard_setImage(const char *text);
 
-DOS_API void dos_qapplication_download_image(const char *imageSource, const char* filePath);
+DOS_API void dos_qguiapplication_download_image(const char *imageSource, const char* filePath);
 
-/// @}
-
-/// \defgroup QApplication QApplication
-/// \brief Functions related to the QApplication class
-/// @{
-
-/// \brief Create a QApplication
-/// \note The created QApplication should be freed by calling dos_qapplication_delete()
-DOS_API void DOS_CALL dos_qapplication_create();
-
-/// \brief Calls the QApplication::exec() function of the current QGuiApplication
-/// \note A QApplication should have been already created through dos_qapplication_create()
-DOS_API void DOS_CALL dos_qapplication_exec(void);
+/// \brief Calls the QGuiApplication::exec() function of the current QGuiApplication
+/// \note A QGuiApplication should have been already created through dos_qguiapplication_create()
+DOS_API void DOS_CALL dos_qguiapplication_exec(void);
 
 /// \brief Invokes a QObject's slot by passing a string containing a signal
 /// \note This method was created because status-go has a non-QT event loop
@@ -127,15 +113,15 @@ DOS_API char * DOS_CALL dos_qurl_host(char* host);
 DOS_API char * DOS_CALL dos_qurl_replaceHostAndAddPath(char* url, char* newScheme, char* newHost, char* pathPrefix);
 
 /// \brief Sets the application icon
-DOS_API void DOS_CALL dos_qapplication_icon(const char *filename);
+DOS_API void DOS_CALL dos_qguiapplication_icon(const char *filename);
 
-/// \brief Calls the QApplication::quit() function of the current QGuiApplication
-/// \note A QApplication should have been already created through dos_qapplication_create()
-DOS_API void DOS_CALL dos_qapplication_quit(void);
+/// \brief Calls the QGuiApplication::quit() function of the current QGuiApplication
+/// \note A QGuiApplication should have been already created through dos_qguiapplication_create()
+DOS_API void DOS_CALL dos_qguiapplication_quit(void);
 
-/// \brief Free the memory of the current QApplication
-/// \note A QApplication should have been already created through dos_qapplication_create()
-DOS_API void DOS_CALL dos_qapplication_delete(void);
+/// \brief Free the memory of the current QGuiApplication
+/// \note A QGuiApplication should have been already created through dos_qguiapplication_create()
+DOS_API void DOS_CALL dos_qguiapplication_delete(void);
 
 /// @}
 
@@ -177,7 +163,7 @@ DOS_API void DOS_CALL dos_qqmlapplicationengine_load_data(DosQQmlApplicationEngi
 /// \param vptr The QQmlApplicationEngine
 /// \param data The UTF-8 string of the path to the translation file (.qm)
 /// \param shouldRetranslate Should retranslate() be called after loading a translation
-DOS_API void DOS_CALL dos_qapplication_load_translation(DosQQmlApplicationEngine *vptr, const char* translationPackage, bool shouldRetranslate);
+DOS_API void DOS_CALL dos_qguiapplication_load_translation(DosQQmlApplicationEngine *vptr, const char* translationPackage, bool shouldRetranslate);
 
 /// \brief Calls the QQmlApplicationEngine::addImportPath function
 /// \param vptr The QQmlApplicationEngine

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -82,8 +82,6 @@ DOS_API void dos_qguiapplication_installEventFilter(DosEvent *vptr);
 
 DOS_API void dos_qguiapplication_clipboard_setText(const char* text);
 
-DOS_API void dos_qguiapplication_installEventFilter(DosStatusEventObject *vptr);
-
 DOS_API void dos_qguiapplication_clipboard_setImage(const char *text);
 
 DOS_API void dos_qguiapplication_download_image(const char *imageSource, const char* filePath);

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -50,7 +50,6 @@
 #ifdef QT_QUICKCONTROLS2_LIB
 #include <QtQuickControls2/QQuickStyle>
 #endif
-#include <QtWidgets/QApplication>
 
 #include "DOtherSide/DOtherSideTypesCpp.h"
 #include "DOtherSide/DosQMetaObject.h"
@@ -123,15 +122,15 @@ char *convert_to_cstring(const QString &source)
     return convert_to_cstring(source.toUtf8());
 }
 
-char *dos_qcoreapplication_application_dir_path()
+char *dos_qguiapplication_application_dir_path()
 {
-    return convert_to_cstring(QCoreApplication::applicationDirPath());
+    return convert_to_cstring(QGuiApplication::applicationDirPath());
 }
 
-void dos_qapplication_enable_hdpi(const char *uiScaleFilePath)
+void dos_qguiapplication_enable_hdpi(const char *uiScaleFilePath)
 {
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 
     QFile scaleFile(QString::fromUtf8(uiScaleFilePath));
     if (scaleFile.open(QIODevice::ReadOnly)) {
@@ -140,9 +139,9 @@ void dos_qapplication_enable_hdpi(const char *uiScaleFilePath)
     }
 }
 
-void dos_qapplication_initialize_opengl()
+void dos_qguiapplication_initialize_opengl()
 {
-    QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+    QGuiApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 }
 
 void dos_qguiapplication_create()
@@ -155,21 +154,21 @@ void dos_qguiapplication_create()
     new QGuiApplication(argc, argv);
 }
 
-void dos_qapplication_clipboard_setText(const char* text)
+void dos_qguiapplication_clipboard_setText(const char* text)
 {
-    QApplication::clipboard()->setText(text);
+    QGuiApplication::clipboard()->setText(text);
 }
 
-void dos_qapplication_clipboard_setImage(const char* text)
+void dos_qguiapplication_clipboard_setImage(const char* text)
 {
     QByteArray btArray =  QString(text).split("base64,")[1].toUtf8();
     QImage image;
     image.loadFromData(QByteArray::fromBase64(btArray));
     Q_ASSERT(!image.isNull());
-    QApplication::clipboard()->setImage(image);
+    QGuiApplication::clipboard()->setImage(image);
 }
 
-void dos_qapplication_download_image(const char *imageSource, const char *filePath)
+void dos_qguiapplication_download_image(const char *imageSource, const char *filePath)
 {
     // Extract file path that can be used to save the image
     QString fileL = QString(filePath).replace(QRegExp("^(file:/{2})|(qrc:/{2})|(http:/{2})"), "");
@@ -211,43 +210,6 @@ void dos_qguiapplication_installEventFilter(::DosEvent* vptr)
     qGuiApp->installEventFilter(qobject);
 }
 
-void dos_qapplication_create()
-{
-    static int argc = 1;
-    static char *argv[] = {(char*)"Status"};
-
-    register_meta_types();
-
-    new QApplication(argc, argv);
-}
-
-void dos_qapplication_delete()
-{
-    delete qApp;
-}
-
-void dos_qapplication_exec()
-{
-    qApp->exec();
-}
-
-void dos_qapplication_icon(const char *filename)
-{
-    qApp->setWindowIcon(QIcon(filename));
-}
-
-void dos_qapplication_quit()
-{
-    // This way we will be safe for quitting the app (avoid potential crashes).
-    QMetaObject::invokeMethod(qApp, "quit", Qt::QueuedConnection);
-}
-
-void dos_qapplication_installEventFilter(::DosEvent* vptr)
-{
-    auto qobject = static_cast<QObject*>(vptr);
-    qApp->installEventFilter(qobject);
-}
-
 ::DosQQmlApplicationEngine *dos_qqmlapplicationengine_create()
 {
     return new QQmlApplicationEngine();
@@ -287,7 +249,7 @@ void dos_qqmlapplicationengine_setNetworkAccessManagerFactory(::DosQQmlApplicati
 void dos_qqmlapplicationengine_load(::DosQQmlApplicationEngine *vptr, const char *filename)
 {
     auto engine = static_cast<QQmlApplicationEngine *>(vptr);
-    engine->load(QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + QDir::separator() + QString(filename)));
+    engine->load(QUrl::fromLocalFile(QGuiApplication::applicationDirPath() + QDir::separator() + QString(filename)));
 }
 
 void dos_qqmlapplicationengine_load_url(::DosQQmlApplicationEngine *vptr, ::DosQUrl *url)
@@ -303,13 +265,13 @@ void dos_qqmlapplicationengine_load_data(::DosQQmlApplicationEngine *vptr, const
     engine->loadData(data);
 }
 
-void dos_qapplication_load_translation(::DosQQmlApplicationEngine *vptr, const char* translationPackage, bool shouldRetranslate)
+void dos_qguiapplication_load_translation(::DosQQmlApplicationEngine *vptr, const char* translationPackage, bool shouldRetranslate)
 {
     if (!m_translator->isEmpty()) {
-        QCoreApplication::removeTranslator(m_translator);
+        QGuiApplication::removeTranslator(m_translator);
     }
     if (m_translator->load(translationPackage)) {
-        bool success = QCoreApplication::installTranslator(m_translator);
+        bool success = QGuiApplication::installTranslator(m_translator);
         auto engine = static_cast<QQmlApplicationEngine *>(vptr);
         if (shouldRetranslate) engine->retranslate();
     } else {
@@ -437,7 +399,7 @@ char *dos_qquickview_source(const ::DosQQuickView *vptr)
 void dos_qquickview_set_source(::DosQQuickView *vptr, const char *filename)
 {
     auto view = static_cast<QQuickView *>(vptr);
-    view->setSource(QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + QDir::separator() + QString(filename)));
+    view->setSource(QUrl::fromLocalFile(QGuiApplication::applicationDirPath() + QDir::separator() + QString(filename)));
 }
 
 void dos_qquickview_set_source_url(::DosQQuickView *vptr, ::DosQUrl *url)
@@ -1123,7 +1085,7 @@ void dos_qabstractitemmodel_dataChanged(::DosQAbstractItemModel *vptr,
     auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
     auto topLeft = static_cast<const QModelIndex *>(topLeftIndex);
     auto bottomRight = static_cast<const QModelIndex *>(bottomRightIndex);
-    auto roles = QVector<int>::fromStdVector(std::vector<int>(rolesArrayPtr, rolesArrayPtr + rolesArrayLength));
+    auto roles = QVector<int>(rolesArrayPtr, rolesArrayPtr + rolesArrayLength);
     model->publicDataChanged(*topLeft, *bottomRight, roles);
 }
 
@@ -1251,14 +1213,14 @@ void dos_qquickstyle_set_fallback_style(const char *style)
 #endif
 }
 
-void dos_qcoreapplication_process_events(DosQEventLoopProcessEventFlag flags)
+void dos_qguiapplication_process_events(DosQEventLoopProcessEventFlag flags)
 {
-    qApp->processEvents(static_cast<QEventLoop::ProcessEventsFlag>(flags));
+    qGuiApp->processEvents(static_cast<QEventLoop::ProcessEventsFlag>(flags));
 }
 
-void dos_qcoreapplication_process_events_timed(DosQEventLoopProcessEventFlag flags, int ms)
+void dos_qguiapplication_process_events_timed(DosQEventLoopProcessEventFlag flags, int ms)
 {
-    qApp->processEvents(static_cast<QEventLoop::ProcessEventsFlag>(flags), ms);
+    qGuiApp->processEvents(static_cast<QEventLoop::ProcessEventsFlag>(flags), ms);
 }
 
 ::DosQNetworkConfigurationManager *dos_qncm_create()

--- a/lib/src/DosQMetaObject.cpp
+++ b/lib/src/DosQMetaObject.cpp
@@ -30,7 +30,7 @@ QList<QByteArray> createParameterNames(const DOS::SignalDefinition &signal)
 {
     QList<QByteArray> result;
     const auto &parameters = signal.parameters;
-    result.reserve(parameters.size());
+    result.reserve(static_cast<int>(parameters.size()));
     for (size_t i = 0; i < parameters.size(); ++i)
         result << parameters[i].name.toUtf8();
     return result;

--- a/lib/src/DosQObjectImpl.cpp
+++ b/lib/src/DosQObjectImpl.cpp
@@ -131,7 +131,7 @@ QVariant DosQObjectImpl::executeSlot(const QString &name, const std::vector<QVar
         argumentsAsVoidPointers.emplace_back((void *)(&args[i]));
 
     // send them to the binding handler
-    m_dObjectCallback(m_dObjectPointer, &slotName, argumentsAsVoidPointers.size(), &argumentsAsVoidPointers[0]);
+    m_dObjectCallback(m_dObjectPointer, &slotName, static_cast<int>(argumentsAsVoidPointers.size()), &argumentsAsVoidPointers[0]);
 
     return result;
 }

--- a/lib/src/DosSpellchecker.cpp
+++ b/lib/src/DosSpellchecker.cpp
@@ -10,7 +10,7 @@
 #include <QLocale>
 
 #include <QRegularExpression>
-#include <QApplication>
+#include <QGuiApplication>
 #include <QDir>
 
 #include <QInputMethod>
@@ -57,8 +57,8 @@ void SpellChecker::initHunspell()
         delete m_hunspell;
     }
 
-    QString dictFile = QApplication::applicationDirPath() + "/dictionaries/" + m_lang  + "/index.dic";
-    QString affixFile = QApplication::applicationDirPath() + "/dictionaries/" + m_lang  + "/index.aff";
+    QString dictFile = QGuiApplication::applicationDirPath() + "/dictionaries/" + m_lang  + "/index.dic";
+    QString affixFile = QGuiApplication::applicationDirPath() + "/dictionaries/" + m_lang  + "/index.aff";
     QByteArray dictFilePathBA = dictFile.toLocal8Bit();
     QByteArray affixFilePathBA = affixFile.toLocal8Bit();
     m_hunspell = new Hunspell(affixFilePathBA.constData(),

--- a/test/test_dotherside.cpp
+++ b/test/test_dotherside.cpp
@@ -7,7 +7,7 @@
 #include <QTest>
 #include <QSignalSpy>
 #include <QTimer>
-#include <QApplication>
+#include <QGuiApplication>
 #include <QQuickWindow>
 #include <QQmlApplicationEngine>
 #include <QQuickItem>
@@ -37,7 +37,7 @@ bool ExecuteTest(int argc, char *argv[])
 template<typename Test>
 bool ExecuteGuiTest(int argc, char *argv[])
 {
-    QApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
     Test test;
     return QTest::qExec(&test, argc, argv) == 0;
 }
@@ -61,28 +61,6 @@ private slots:
         dos_qguiapplication_exec();
         QVERIFY(quit);
         dos_qguiapplication_delete();
-    }
-};
-
-/*
- * Test QApplication
- */
-class TestQApplication : public QObject
-{
-    Q_OBJECT
-
-private slots:
-    void testExecution()
-    {
-        bool quit = false;
-        dos_qapplication_create("test");
-        QTimer::singleShot(100, [&quit]() {
-            quit = true;
-            dos_qapplication_quit();
-        });
-        dos_qapplication_exec();
-        QVERIFY(quit);
-        dos_qapplication_delete();
     }
 };
 
@@ -737,7 +715,6 @@ int main(int argc, char *argv[])
 
     bool success = true;
     success &= ExecuteTest<TestQGuiApplication>(argc, argv);
-    success &= ExecuteTest<TestQApplication>(argc, argv);
     success &= ExecuteTest<TestQVariant>(argc, argv);
     success &= ExecuteTest<TestQUrl>(argc, argv);
     success &= ExecuteTest<TestQModelIndex>(argc, argv);


### PR DESCRIPTION
`SystemTrayIcon` was not working again.. because of the mess we had with Q*Application classes use.
The error I was getting when starting the app was:
`QApplication::regClass: Registering window class 'QTrayIconMessageWindowClass' failed. (Class already exists.)`

I want to prevent this once and for all and use `QGuiApplication` everywhere.