### PR TITLE
register SortFilterProxyModel types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ nimcache
 *.orig
 doc
 cmake-build-*
+.cache
 
 # libraries
 *.a

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/SortFilterProxyModel"]
+	path = vendor/SortFilterProxyModel
+	url = git@github.com:status-im/SortFilterProxyModel.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/SortFilterProxyModel"]
 	path = vendor/SortFilterProxyModel
-	url = git@github.com:status-im/SortFilterProxyModel.git
+	url = https://github.com/status-im/SortFilterProxyModel.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     endif()
 endif()
 
+add_subdirectory(vendor/SortFilterProxyModel)
 add_subdirectory(lib)
 
 if(ENABLE_DOCS)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,10 +27,10 @@ macro(add_target name type)
         target_include_directories(${name} PUBLIC include include/Qt)
     endif()
 
-    target_link_libraries(${name} PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Qml Qt5::Quick Qt5::Network Qt5::Multimedia)
+    target_link_libraries(${name} PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Qml Qt5::Quick Qt5::Network Qt5::Multimedia SortFilterProxyModel)
 
     # for DOtherSide.pc
-    set(PC_REQUIRES "Qt5Core, Qt5Gui, Qt5Widgets, Qt5Qml, Qt5Quick, Qt5Network, Qt5DBus, Qt5Multimedia")
+    set(PC_REQUIRES "Qt5Core, Qt5Gui, Qt5Widgets, Qt5Qml, Qt5Quick, Qt5Network, Qt5DBus, Qt5Multimedia SortFilterProxyModel")
     if (${Qt5QuickControls2_FOUND})
         target_link_libraries(${name} PRIVATE Qt5::QuickControls2)
         set(PC_REQUIRES "${PC_REQUIRES}, Qt5QuickControls2")

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -74,6 +74,8 @@
 #include "DOtherSide/Status/QClipboardProxy.h"
 #include "DOtherSide/DosSpellchecker.h"
 
+#include <qqmlsortfilterproxymodeltypes.h>
+
 namespace {
 
 void register_meta_types()
@@ -83,7 +85,7 @@ void register_meta_types()
     qmlRegisterType<StatusSyntaxHighlighterHelper>("DotherSide", 0 , 1, "StatusSyntaxHighlighter");
     qmlRegisterType<SpellChecker>("DotherSide", 0, 1, "SpellChecker");
     qmlRegisterSingletonType<QClipboardProxy>("DotherSide", 0 , 1, "QClipboardProxy", &QClipboardProxy::qmlInstance);
-
+    qqsfpm::registerTypes();
 }
 
 }


### PR DESCRIPTION
relates: https://github.com/status-im/status-desktop/issues/6510
- [chore(git): add vendor/SortFilterProxyModel](https://github.com/status-im/dotherside/commit/204b6121f3ceff83a0c7b55bd0405c27b2983787)
- [feat: register SortFilterProxyModel types](https://github.com/status-im/dotherside/commit/8a8735cebb1c7d472b8ea70fd4deeb783cdc0ea1)
   - it allows to `import SortFilterProxyModel 0.2`