### PR TITLE
temp(translations): Retranslate call disabled

### DIFF
--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -385,7 +385,8 @@ void dos_qguiapplication_load_translation(::DosQQmlApplicationEngine *vptr, cons
     if (m_translator->load(translationPackage)) {
         bool success = QGuiApplication::installTranslator(m_translator);
         auto engine = static_cast<QQmlApplicationEngine *>(vptr);
-        if (shouldRetranslate) engine->retranslate();
+        // IMPORTANT: Workaround to temporary resolve the crash we have when language is changed (`startupModule` is null and some qml bindings are still calling this dead pointer)
+        // if (shouldRetranslate) engine->retranslate();
     } else {
         printf("Failed to load translation file %s\n", translationPackage);
     }


### PR DESCRIPTION
Will temporary help to fix https://github.com/status-im/status-desktop/issues/7709

### What does the PR do

Retranslate call disabled for all OS --> Workaround to temporary resolve the crash we have when language is changed in desktop app (`startupModule` in desktop is null and some qml bindings, during retranslate evaluation, are still calling this dead pointer).