### PR TITLE
feat(QClipboardProxy): add support for images, html and urls

### DIFF
--- a/lib/include/DOtherSide/Status/QClipboardProxy.h
+++ b/lib/include/DOtherSide/Status/QClipboardProxy.h
@@ -1,23 +1,49 @@
 #pragma once
 
 #include <QObject>
-#include <QString>
-#include <QQmlEngine>
-#include <QJSEngine>
+
+class QClipboard;
+class QJSEngine;
+class QQmlEngine;
 
 class QClipboardProxy : public QObject
 {
     Q_OBJECT
 
     Q_DISABLE_COPY(QClipboardProxy)
-    Q_PROPERTY(QString text READ text NOTIFY textChanged)
+
+    Q_PROPERTY(bool hasText READ hasText NOTIFY contentChanged)
+    Q_PROPERTY(QString text READ text NOTIFY contentChanged)
+
+    Q_PROPERTY(bool hasHtml READ hasHtml NOTIFY contentChanged)
+    Q_PROPERTY(QString html READ html NOTIFY contentChanged)
+
+    Q_PROPERTY(bool hasImage READ hasImage NOTIFY contentChanged)
+    Q_PROPERTY(QImage image READ image NOTIFY contentChanged)
+    Q_PROPERTY(QByteArray imageBase64 READ imageBase64 NOTIFY contentChanged)
+
+    Q_PROPERTY(bool hasUrls READ hasUrls NOTIFY contentChanged)
+    Q_PROPERTY(QList<QUrl> urls READ urls NOTIFY contentChanged)
 
     QClipboardProxy();
 
-public:
+    bool hasText() const;
     QString text() const;
 
-    static QObject *qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine)
+    bool hasHtml() const;
+    QString html() const;
+
+    bool hasImage() const;
+    QImage image() const;
+    QByteArray imageBase64() const;
+
+    bool hasUrls() const;
+    QList<QUrl> urls() const;
+
+    QClipboard* m_clipboard{nullptr};
+
+public:
+    static QObject* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine)
     {
         Q_UNUSED(engine);
         Q_UNUSED(scriptEngine);
@@ -26,5 +52,5 @@ public:
     }
 
 signals:
-    void textChanged();
+    void contentChanged();
 };

--- a/lib/src/Status/QClipboardProxy.cpp
+++ b/lib/src/Status/QClipboardProxy.cpp
@@ -1,14 +1,69 @@
 #include "DOtherSide/Status/QClipboardProxy.h"
 
-#include <QGuiApplication>
+#include <QBuffer>
 #include <QClipboard>
+#include <QGuiApplication>
+#include <QImage>
+#include <QMimeData>
+#include <QUrl>
 
 QClipboardProxy::QClipboardProxy()
+    : m_clipboard(QGuiApplication::clipboard())
 {
-    connect(QGuiApplication::clipboard(), &QClipboard::dataChanged, this, &QClipboardProxy::textChanged);
+    connect(m_clipboard, &QClipboard::changed, this, [this](QClipboard::Mode mode) {
+        if (mode == QClipboard::Clipboard)
+            emit contentChanged();
+    });
+}
+
+bool QClipboardProxy::hasText() const
+{
+    return m_clipboard->mimeData()->hasText();
 }
 
 QString QClipboardProxy::text() const
 {
-    return QGuiApplication::clipboard()->text();
+    return m_clipboard->text();
+}
+
+bool QClipboardProxy::hasHtml() const
+{
+    return m_clipboard->mimeData()->hasHtml();
+}
+
+QString QClipboardProxy::html() const
+{
+    return m_clipboard->mimeData()->html();
+}
+
+bool QClipboardProxy::hasImage() const
+{
+    return m_clipboard->mimeData()->hasImage();
+}
+
+QImage QClipboardProxy::image() const
+{
+    return m_clipboard->image();
+}
+
+QByteArray QClipboardProxy::imageBase64() const
+{
+    if (!hasImage())
+        return {};
+
+    const auto img = image();
+    QByteArray byteArray;
+    QBuffer buffer(&byteArray);
+    img.save(&buffer, "PNG"); // writes the image in PNG format inside the buffer
+    return QByteArrayLiteral("data:image/png;base64,") + byteArray.toBase64().constData();
+}
+
+bool QClipboardProxy::hasUrls() const
+{
+    return m_clipboard->mimeData()->hasUrls();
+}
+
+QList<QUrl> QClipboardProxy::urls() const
+{
+    return m_clipboard->mimeData()->urls();
 }


### PR DESCRIPTION
- also add discovery properties (hasText/hasImage/hasHtml/hasUrls)
- support for image format is also provided as base64 encoded byte array wrapper

Related: https://github.com/status-im/status-desktop/issues/3395