### PR TITLE
fix: use QClipboard properly in QClipboardProxy

### DIFF
--- a/lib/include/DOtherSide/Status/QClipboardProxy.h
+++ b/lib/include/DOtherSide/Status/QClipboardProxy.h
@@ -1,24 +1,20 @@
-#ifndef QCLIPBOARDPROXY_HPP
-#define QCLIPBOARDPROXY_HPP
+#pragma once
 
 #include <QObject>
 #include <QString>
 #include <QQmlEngine>
 #include <QJSEngine>
 
-class QClipboard;
-
 class QClipboardProxy : public QObject
 {
     Q_OBJECT
+
     Q_DISABLE_COPY(QClipboardProxy)
     Q_PROPERTY(QString text READ text NOTIFY textChanged)
 
-    QClipboardProxy() {}
+    QClipboardProxy();
 
 public:
-    explicit QClipboardProxy(QClipboard*);
-
     QString text() const;
 
     static QObject *qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine)
@@ -31,9 +27,4 @@ public:
 
 signals:
     void textChanged();
-
-private:
-    QClipboard* clipboard;
 };
-
-#endif // QCLIPBOARDPROXY_HPP

--- a/lib/src/Status/QClipboardProxy.cpp
+++ b/lib/src/Status/QClipboardProxy.cpp
@@ -1,13 +1,14 @@
 #include "DOtherSide/Status/QClipboardProxy.h"
 
+#include <QGuiApplication>
 #include <QClipboard>
 
-QClipboardProxy::QClipboardProxy(QClipboard* c) : clipboard(c)
+QClipboardProxy::QClipboardProxy()
 {
-    QObject::connect(c, SIGNAL (dataChanged()), this, SLOT(textChanged()));
+    connect(QGuiApplication::clipboard(), &QClipboard::dataChanged, this, &QClipboardProxy::textChanged);
 }
 
 QString QClipboardProxy::text() const
 {
-    return clipboard->text();
+    return QGuiApplication::clipboard()->text();
 }


### PR DESCRIPTION
- constructor with connection was never called
- `textChanged` was never emitted
- `clipboard` member was uninitialized

https://user-images.githubusercontent.com/33099791/203811603-a3662382-54a6-41d8-a756-cdef6721003d.mp4

