### PR TITLE
fix(QClipboardProxy): return imageBase64 as a QString

### DIFF
--- a/lib/include/DOtherSide/Status/QClipboardProxy.h
+++ b/lib/include/DOtherSide/Status/QClipboardProxy.h
@@ -20,7 +20,7 @@ class QClipboardProxy : public QObject
 
     Q_PROPERTY(bool hasImage READ hasImage NOTIFY contentChanged)
     Q_PROPERTY(QImage image READ image NOTIFY contentChanged)
-    Q_PROPERTY(QByteArray imageBase64 READ imageBase64 NOTIFY contentChanged)
+    Q_PROPERTY(QString imageBase64 READ imageBase64 NOTIFY contentChanged)
 
     Q_PROPERTY(bool hasUrls READ hasUrls NOTIFY contentChanged)
     Q_PROPERTY(QList<QUrl> urls READ urls NOTIFY contentChanged)
@@ -35,7 +35,7 @@ class QClipboardProxy : public QObject
 
     bool hasImage() const;
     QImage image() const;
-    QByteArray imageBase64() const;
+    QString imageBase64() const;
 
     bool hasUrls() const;
     QList<QUrl> urls() const;

--- a/lib/src/Status/QClipboardProxy.cpp
+++ b/lib/src/Status/QClipboardProxy.cpp
@@ -46,7 +46,7 @@ QImage QClipboardProxy::image() const
     return m_clipboard->image();
 }
 
-QByteArray QClipboardProxy::imageBase64() const
+QString QClipboardProxy::imageBase64() const
 {
     if (!hasImage())
         return {};
@@ -55,7 +55,7 @@ QByteArray QClipboardProxy::imageBase64() const
     QByteArray byteArray;
     QBuffer buffer(&byteArray);
     img.save(&buffer, "PNG"); // writes the image in PNG format inside the buffer
-    return QByteArrayLiteral("data:image/png;base64,") + byteArray.toBase64().constData();
+    return QStringLiteral("data:image/png;base64,") + byteArray.toBase64();
 }
 
 bool QClipboardProxy::hasUrls() const


### PR DESCRIPTION
for better interop with NIM/status-go