### PR TITLE
refactor: default clipboard image base64 to JPG instead of PNG

### DIFF
--- a/lib/src/Status/QClipboardProxy.cpp
+++ b/lib/src/Status/QClipboardProxy.cpp
@@ -54,8 +54,8 @@ QString QClipboardProxy::imageBase64() const
     const auto img = image();
     QByteArray byteArray;
     QBuffer buffer(&byteArray);
-    img.save(&buffer, "PNG"); // writes the image in PNG format inside the buffer
-    return QStringLiteral("data:image/png;base64,") + byteArray.toBase64();
+    img.save(&buffer, "JPG");
+    return QStringLiteral("data:image/jpeg;base64,") + byteArray.toBase64();
 }
 
 bool QClipboardProxy::hasUrls() const


### PR DESCRIPTION
Hardcoding this is already far from ideal. We should at least use the same type that's later used in desktop before sending images to status-go, **before** this gets fixed properly.

The next step will be to detect codecs and use them them dynamically.