### PR TITLE
feat: Add additional utilities for real-time app inspection

### DIFF
--- a/lib/include/DOtherSide/Status/Monitoring/ContextPropertiesModel.h
+++ b/lib/include/DOtherSide/Status/Monitoring/ContextPropertiesModel.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QObject>
+#include <QAbstractListModel>
+
+class ContextPropertiesModel : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    explicit ContextPropertiesModel(QObject* parent = nullptr);
+
+    static constexpr int NameRole = Qt::UserRole + 1;
+
+    int rowCount(const QModelIndex &parent) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    void addContextProperty(const QString &property);
+
+private:
+    QStringList m_contextProperties;
+};

--- a/lib/include/DOtherSide/Status/Monitoring/Monitor.h
+++ b/lib/include/DOtherSide/Status/Monitoring/Monitor.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <QObject>
+#include <QJSValue>
+
+#include "ContextPropertiesModel.h"
 
 class QQmlApplicationEngine;
 class QQmlEngine;
@@ -9,21 +12,23 @@ class QJSEngine;
 class Monitor : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QStringList contexPropertiesNames READ getContextPropertiesNames
-               NOTIFY contextPropertiesNamesChanged)
+    Q_PROPERTY(ContextPropertiesModel* contexPropertiesModel
+               READ contexPropertiesModel CONSTANT)
 
     Monitor() = default;
 
 public:
     void initialize(QQmlApplicationEngine *engine);
-    QStringList getContextPropertiesNames() const;
+    ContextPropertiesModel* contexPropertiesModel();
     void addContextPropertyName(const QString &contextPropertyName);
+
+    Q_INVOKABLE bool isModel(const QVariant &obj) const;
+    Q_INVOKABLE QString typeName(const QVariant &obj) const;
+    Q_INVOKABLE QJSValue modelRoles(QAbstractItemModel *model) const;
 
     static Monitor& instance();
     static QObject* qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine);
-signals:
-    void contextPropertiesNamesChanged();
 
 private:
-    QStringList m_contexPropertiesNames;
+    ContextPropertiesModel m_contexPropertiesModel;
 };

--- a/lib/src/Status/Monitoring/ContextPropertiesModel.cpp
+++ b/lib/src/Status/Monitoring/ContextPropertiesModel.cpp
@@ -1,0 +1,39 @@
+#include "DOtherSide/Status/Monitoring/ContextPropertiesModel.h"
+
+ContextPropertiesModel::ContextPropertiesModel(QObject* parent)
+    : QAbstractListModel(parent)
+{
+}
+
+int ContextPropertiesModel::rowCount(const QModelIndex &parent) const
+{
+    return m_contextProperties.size();
+}
+
+QVariant ContextPropertiesModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return {};
+
+    return m_contextProperties.at(index.row());
+}
+
+QHash<int, QByteArray> ContextPropertiesModel::roleNames() const
+{
+   static QHash<int, QByteArray> roles {
+       { NameRole, QByteArrayLiteral("name") }
+   };
+
+   return roles;
+}
+
+void ContextPropertiesModel::addContextProperty(const QString &property)
+{
+    if (m_contextProperties.contains(property))
+        return;
+
+    const auto currentCount = m_contextProperties.size();
+    beginInsertRows(QModelIndex(), currentCount, currentCount);
+    m_contextProperties << property;
+    endInsertRows();
+}


### PR DESCRIPTION
## What does the PR do

Adds some utilities necessary to inspect properties injected from a backend.

- context properties names exposed as a model
- checking if object is a model
- exposing human-readable type name
- exposing role names for models

Closes: https://github.com/status-im/status-desktop/issues/8787