### PR TITLE
fix(MacosCmake): Prepend .mm files in order to override cpp implement…

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,7 +20,8 @@ macro(add_target name type)
 
     if(APPLE)
         file(GLOB MM_FILES src/*.mm src/Status/*.mm)
-        list(APPEND SOURCES ${MM_FILES})
+        #prepend items because .mm files need build priority to override cpp impl
+        list(INSERT SOURCES 0 ${MM_FILES})
     endif()
 
     add_library(${name} ${type} ${SOURCES} ${HEADERS} ${MONITORING_SOURCES} ${MONITORING_HEADERS})


### PR DESCRIPTION
Fixing [#9126](https://github.com/status-im/status-desktop/issues/9126)

Looks like DOtherSide project is using sources order to override implementations on MacOs. The order has been recently changed in #85. This PR restores the sources order.