### PR TITLE
chore: add an explicit `CorePrivate` to the list of Qt modules

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,7 +7,7 @@ set(MONITORING_QML_ENTRY_POINT "" CACHE STRING "QML file intended to start the m
 
 find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
 
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Qml Gui Quick QuickControls2 Widgets WebView REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core CorePrivate Qml Gui Quick QuickControls2 Widgets WebView REQUIRED)
 
 if(MONITORING)
     include(../../../ui/MonitoringSources.cmake)


### PR DESCRIPTION
- fixes compilation against Qt 6.10