### PR TITLE
feat(deep-links): add code to support deep links on Android

### DIFF
--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -1044,6 +1044,7 @@ DOS_API void DOS_CALL dos_singleinstance_delete(DosSingleInstance *vptr);
 
 DOS_API DosEvent* dos_event_create_urlSchemeEvent();
 DOS_API void dos_event_delete(DosEvent* vptr);
+DOS_API void dos_event_set_urlSchemeEvent_instance(DosEvent* vptr);
 
 #pragma endregion
 

--- a/lib/include/DOtherSide/Status/UrlSchemeEvent.h
+++ b/lib/include/DOtherSide/Status/UrlSchemeEvent.h
@@ -9,6 +9,10 @@ namespace Status
     {
         Q_OBJECT
 
+        public:
+            void emitDeepLinkToQt(const QString& url);
+            static void setInstance(UrlSchemeEvent* instance);
+
         protected:
             bool eventFilter(QObject* obj, QEvent* event) override;
 

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -1471,6 +1471,14 @@ bool dos_singleinstance_isfirst(DosSingleInstance *vptr)
     return new Status::UrlSchemeEvent();
 }
 
+void dos_event_set_urlSchemeEvent_instance(DosEvent* vptr)
+{
+    if (vptr) {
+        auto urlSchemeEvent = static_cast<Status::UrlSchemeEvent*>(vptr);
+        Status::UrlSchemeEvent::setInstance(urlSchemeEvent);
+    }
+}
+
 void dos_event_delete(DosEvent* vptr)
 {
     auto qobject = static_cast<QObject*>(vptr);

--- a/lib/src/Status/UrlSchemeEvent.cpp
+++ b/lib/src/Status/UrlSchemeEvent.cpp
@@ -3,6 +3,9 @@
 using namespace Status;
 
 #include <QFileOpenEvent>
+#if defined(Q_OS_ANDROID)
+    #include <jni.h>
+#endif // Q_OS_ANDROID
 
 bool UrlSchemeEvent::eventFilter(QObject* obj, QEvent* event)
 {
@@ -19,3 +22,31 @@ bool UrlSchemeEvent::eventFilter(QObject* obj, QEvent* event)
 
     return QObject::eventFilter(obj, event);
 }
+
+void UrlSchemeEvent::emitDeepLinkToQt(const QString& url)
+{
+    if (url.isEmpty()) return;
+
+    emit urlActivated(url);
+}
+
+static UrlSchemeEvent* g_urlSchemeEventInstance = nullptr;
+
+void UrlSchemeEvent::setInstance(UrlSchemeEvent* instance)
+{
+    g_urlSchemeEventInstance = instance;
+}
+
+#ifdef Q_OS_ANDROID
+extern "C" JNIEXPORT void JNICALL
+Java_app_status_mobile_StatusQtActivity_passDeepLinkToQt(JNIEnv* /*env*/, jclass /*clazz*/, jstring url)
+{
+    const QString deepLink = QJniObject(url).toString();
+    if (deepLink.isEmpty()) return;
+
+    if (g_urlSchemeEventInstance) {
+        g_urlSchemeEventInstance->emitDeepLinkToQt(deepLink);
+    }
+}
+#endif
+


### PR DESCRIPTION
Needed for https://github.com/status-im/status-app/issues/19562

Adds a Java event listener that then calls a signal that can be used in Nim. For that to work, we must first set the instance, because we need to call that final emit statically.