### PR TITLE
fix: Enable profiling on mobile

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,6 +47,7 @@ macro(add_target name type)
     target_compile_definitions(${name} PRIVATE $<$<CONFIG:Debug>:QT_QML_DEBUG>)
     if(DEFINED QML_DEBUG_PORT)
         target_compile_definitions(${name} PRIVATE QML_DEBUG_PORT=${QML_DEBUG_PORT})
+        target_compile_definitions(${name} PRIVATE QT_QML_DEBUG)
     endif()
 
     if(APPLE)


### PR DESCRIPTION
Add QT_QML_DEBUG define when qml profiler needs to be enabled.