### PR TITLE
fix: harden context functions to avoid crashes

### DIFF
--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -367,7 +367,9 @@ void dos_qqmlapplicationengine_add_import_path(::DosQQmlApplicationEngine *vptr,
 ::DosQQmlContext *dos_qqmlapplicationengine_context(::DosQQmlApplicationEngine *vptr)
 {
     auto engine = static_cast<QQmlApplicationEngine *>(vptr);
-    engine->rootContext();
+    if (!engine)
+        return nullptr;
+
     return engine->rootContext();
 }
 
@@ -531,6 +533,9 @@ void dos_qqmlcontext_setcontextproperty(::DosQQmlContext *vptr, const char *name
 {
     auto context = static_cast<QQmlContext *>(vptr);
     auto variant = static_cast<QVariant *>(value);
+    if (!context || !variant || !name)
+        return;
+
     context->setContextProperty(QString::fromUtf8(name), *variant);
 
 #ifdef MONITORING


### PR DESCRIPTION
Part of https://github.com/status-im/status-app/issues/21034