### PR TITLE
chore: add a `closingDown` guard for quit/exit

### DIFF
--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -253,11 +253,15 @@ void dos_qguiapplication_exec()
 // Quit can be caught by `onClosing`, so if you want to terminate the app for good, use `exit` instead.
 void dos_qguiapplication_quit()
 {
-    QMetaObject::invokeMethod(qGuiApp, "quit", Qt::QueuedConnection);
+  if (qGuiApp->closingDown())
+    return;
+  QMetaObject::invokeMethod(qGuiApp, &QGuiApplication::quit, Qt::QueuedConnection);
 }
 void dos_qguiapplication_exit()
 {
-    QMetaObject::invokeMethod(qGuiApp, "exit", Qt::QueuedConnection);
+  if (qGuiApp->closingDown())
+    return;
+  QMetaObject::invokeMethod(qGuiApp, &QGuiApplication::exit, Qt::QueuedConnection, 0);
 }
 
 void dos_qguiapplication_icon(const char *filename)


### PR DESCRIPTION
- also use the typesafe functors, instead of string based method lookup

Iterates https://github.com/status-im/status-app/issues/21082